### PR TITLE
Install battery in /usr/local/bin so it's on the path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ RUN git clone https://github.com/VoltLang/Watt.git && \
     git clone https://github.com/VoltLang/Volta.git && \
     wget https://github.com/VoltLang/Battery/releases/download/v0.1.13/battery-0.1.13-x86_64-linux.tar.gz && \
     tar xzvf battery-0.1.13-x86_64-linux.tar.gz && \
-    rm battery-0.1.13-x86_64-linux.tar.gz
+    rm battery-0.1.13-x86_64-linux.tar.gz && \
+    mv battery /usr/local/bin
 
 WORKDIR $HOME
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ $ docker run -it --name volt volt:latest
 $ mkdir -p app/src
 $ cd app
 $ # write battery.txt and volt script ...
-$ $HOME/volt/battery config $HOME/volt/Volta $HOME/volt/Watt .
-$ $HOME/volt/battery build
+$ battery config $HOME/volt/Volta $HOME/volt/Watt .
+$ battery build
 ```


### PR DESCRIPTION
This makes it slightly less awkward to use battery in the docker image.

Cheers, Jakob.