### PR TITLE
Update install to work on bionic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,8 @@ FROM ubuntu:latest
 MAINTAINER Yoshihiro Tanaka <contact@cordea.jp>
 
 
-RUN apt-get -y update && \
-    apt-get install -y wget llvm-4.0 clang-4.0 nasm git libcurl4-openssl-dev zlib1g-dev && \
-    wget http://master.dl.sourceforge.net/project/d-apt/files/d-apt.list -O /etc/apt/sources.list.d/d-apt.list && \
-    wget -qO - https://dlang.org/d-keyring.gpg | apt-key add - && \
-    apt-get -y update && \
-    apt-get install -y --allow-unauthenticated dmd-bin
+RUN apt -y update && \
+    apt -y install wget gdc-6 llvm-6.0 clang-6.0 lld-6.0 nasm git libcurl-openssl1.0-dev zlib1g-dev
 
 ENV HOME /root/
 
@@ -20,9 +16,9 @@ WORKDIR $HOME/volt
 
 RUN git clone https://github.com/VoltLang/Watt.git && \
     git clone https://github.com/VoltLang/Volta.git && \
-    wget https://github.com/VoltLang/Battery/releases/download/v0.1.13/battery-0.1.13-x86_64-linux.tar.gz && \
-    tar xzvf battery-0.1.13-x86_64-linux.tar.gz && \
-    rm battery-0.1.13-x86_64-linux.tar.gz && \
+    wget https://github.com/VoltLang/Battery/releases/download/v0.1.18/battery-0.1.18-x86_64-linux.tar.gz && \
+    tar xzvf battery-0.1.18-x86_64-linux.tar.gz && \
+    rm battery-0.1.18-x86_64-linux.tar.gz && \
     mv battery /usr/local/bin
 
 WORKDIR $HOME


### PR DESCRIPTION
Switches to llvm-6.0 that is available on Bionic.
Install lld if user wants to use ThinLTO.
Uses the correct libcurl package.
Switches to GDC for bootstrapping.